### PR TITLE
Fixed the bug with the ball firing because of the button press click

### DIFF
--- a/src/actions/game_control.rs
+++ b/src/actions/game_control.rs
@@ -20,8 +20,8 @@ impl GameControl {
                 keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right)
             }
             GameControl::Action => {
-                keyboard_input.pressed(KeyCode::Space)
-                    || mouse_button_input.pressed(MouseButton::Left)
+                keyboard_input.just_pressed(KeyCode::Space)
+                    || mouse_button_input.just_pressed(MouseButton::Left)
             }
         }
     }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
 use crate::actions::game_control::{get_movement, GameControl};
-use crate::GameState;
 
 mod game_control;
 
@@ -13,11 +12,8 @@ impl Plugin for ActionsPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<InputEvent>()
             .init_resource::<Actions>()
-            .add_system_set(
-                SystemSet::on_update(GameState::Playing)
-                    .with_system(set_movement_actions)
-                    .with_system(call_input_events),
-            );
+            .add_system(set_movement_actions)
+            .add_system(call_input_events);
     }
 }
 

--- a/src/ball.rs
+++ b/src/ball.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
 use crate::{
-    actions::Actions,
+    actions::InputEvent,
     assets::TextureAssets,
     block::Block,
     paddle::{Paddle, PaddleSystem},
@@ -230,10 +230,12 @@ fn lose_condition(
     if transform.translation.y < -(window.height() / 2.) && state.set(GameState::Menu).is_err() {}
 }
 
-fn ball_control(mut ball_query: Query<&mut Ball>, actions: Res<Actions>) {
+fn ball_control(mut ball_query: Query<&mut Ball>, mut input_events: EventReader<InputEvent>) {
     for mut ball in ball_query.iter_mut() {
-        if actions.primary_action {
-            ball.state = BallState::Free;
+        for input_event in input_events.iter() {
+            if *input_event == InputEvent::PrimaryAction {
+                ball.state = BallState::Free;
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,5 @@ use arkanoid::ArkanoidPlugin;
 use bevy::prelude::*;
 
 fn main() {
-    App::new().add_plugin(ArkanoidPlugin).run();aaa
+    App::new().add_plugin(ArkanoidPlugin).run();
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -79,7 +79,9 @@ fn play_button_interaction(
 ) {
     for interaction in &mut interaction_query {
         // If the button was released
-        if *interaction != Interaction::Clicked && *previous_interaction_state == Interaction::Clicked {
+        if *interaction != Interaction::Clicked
+            && *previous_interaction_state == Interaction::Clicked
+        {
             let _ = state.set(GameState::Playing);
         }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -74,11 +74,15 @@ fn spawn_menu(mut commands: Commands, fonts: Res<FontAssets>) {
 
 fn play_button_interaction(
     mut interaction_query: Query<&Interaction, (Changed<Interaction>, With<PlayButton>)>,
+    mut previous_interaction_state: Local<Interaction>,
     mut state: ResMut<State<GameState>>,
 ) {
     for interaction in &mut interaction_query {
-        if *interaction == Interaction::Clicked {
+        // If the button was released
+        if *interaction != Interaction::Clicked && *previous_interaction_state == Interaction::Clicked {
             let _ = state.set(GameState::Playing);
         }
+
+        *previous_interaction_state = *interaction;
     }
 }


### PR DESCRIPTION
The ball automatically fired at the start of the game, because it registered the mouse press of clicking the start button. I fixed this by making the game start when the button is released instead of pressed. I also added an alternative, event-based input system that fits the one-time input events better.

`TODO: Add different button colors for the hovered and the pressed state`